### PR TITLE
 Add timeslot signup notifications

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -15,16 +15,18 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Observation activity version information.
+ * Defines message permissions.
  *
- * @package   mod_observation
- * @copyright  2021 Endurer Solutions Team
+ * @package mod_observation
+ * @copyright 2021 Endurer Solutions Team
  * @author Matthew Hilton <mj.hilton@outlook.com>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021052520;
-$plugin->requires  = 2021052500;
-$plugin->component = 'mod_observation';
+$messageproviders = array(
+    // Confirm timeslot signup.
+    'confirmsignup' => array(
+    ),
+);

--- a/lang/en/observation.php
+++ b/lang/en/observation.php
@@ -158,3 +158,7 @@ $string['cannotpreviewslots'] = 'Could not preview timeslots: {$a}.';
 $string['formincomplete'] = 'Form incomplete';
 $string['endbeforestart'] = 'End time must be after the start time.';
 $string['create'] = 'Create';
+$string['messageprovider:confirmsignup'] = 'Confirmation of your observation signup';
+$string['viewsignup'] = 'View time slot signup';
+$string['signupconfirm'] = '{$a} - Timeslot registration confirmation';
+$string['signuptime'] = 'Signup time';

--- a/templates/confirm_message.mustache
+++ b/templates/confirm_message.mustache
@@ -1,0 +1,40 @@
+{{!
+    This file is part of Moodle - https://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template mod_observation/confirm_message
+
+    Example context (json):
+    {
+        "start_time_formatted": "Wed 5 June",
+        "current_time_formatted": "Wed 5 June",
+        "timeslot": {
+            "duration": 10
+        },
+        "observation": {
+            "name": "Lab 1"
+        }
+    }
+}}
+
+<b> Timeslot registration details </b>
+
+<p> Start Time: {{start_time_formatted}} </p>
+<p> Duration: {{timeslot.duration}} minutes </p>
+
+<b> Other details </b>
+<p> Registration Time: {{current_time_formatted}} </p>
+<p> Activity: {{observation.name}}

--- a/tests/timeslot_joining_test.php
+++ b/tests/timeslot_joining_test.php
@@ -20,7 +20,7 @@
  * @package    mod_observation
  * @category   test
  * @copyright  2021 Endurer Solutions Team
- * @author Jack Kepper <Jack@Kepper.net>
+ * @author Jack Kepper <Jack@Kepper.net>, Matthew Hilton <mj.hilton@outlook.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -31,7 +31,7 @@ defined('MOODLE_INTERNAL') || die();
  * @package    mod_observation
  * @category   test
  * @copyright  2021 Endurer Solutions Team
- * @author Jack Kepper <Jack@Kepper.net>
+ * @author Jack Kepper <Jack@Kepper.net>, Matthew Hilton <mj.hilton@outlook.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class timeslot_joining_test extends advanced_testcase {
@@ -132,5 +132,20 @@ class timeslot_joining_test extends advanced_testcase {
         // Observee 2 tries to join timeslot 1.
         $this->expectException('moodle_exception');
         \mod_observation\timeslot_manager::timeslot_signup($obid, $this->slot1id, $this->observee2->id);
+    }
+
+     /**
+      * Tests notifications on timeslot signup
+      */
+    public function test_signup_notification() {
+        $obid = $this->instance->id;
+
+        $this->preventResetByRollback();
+        $sink = $this->redirectMessages();
+
+        \mod_observation\timeslot_manager::timeslot_signup($obid, $this->slot1id, $this->observee->id);
+
+        $messages = $sink->get_messages();
+        $this->assertEquals(1, count($messages));
     }
 }


### PR DESCRIPTION
Adds timeslot signup notifications - note the notifications for the activity are disabled by default in moodle, notifications will only work if they are enabled.

Closes #9 