### PR TITLE
Adds timeslot notifications via scheduled tasks

### DIFF
--- a/classes/form/notificationeditor.php
+++ b/classes/form/notificationeditor.php
@@ -48,6 +48,7 @@ class notificationeditor extends \moodleform {
         $mform->addElement('header', 'notificationheader', get_string('createnotification', 'observation'));
 
         $options = [
+            MINSECS => get_string('minutes').' '.get_string('before', 'observation'),
             HOURSECS => get_string('hours').' '.get_string('before', 'observation'),
             DAYSECS => get_string('days').' '.get_string('before', 'observation'),
         ];
@@ -61,8 +62,6 @@ class notificationeditor extends \moodleform {
 
         $mform->addGroup($intervalselector, 'select_group', get_string('receivenotification', 'observation'), null, false);
         $mform->setType('interval_amount', PARAM_INT);
-
-        $mform->addElement('duration', 'interval_test');
 
         // Hidden form elements.
         $mform->addElement('hidden', 'id', $prefill['id']);

--- a/classes/timeslot_manager.php
+++ b/classes/timeslot_manager.php
@@ -453,6 +453,13 @@ class timeslot_manager {
             throw $error;
         }
 
+        // Delete timeslot notifications.
+        $notifications = self::get_users_notifications($observationid, $userid);
+
+        foreach ($notifications as $n) {
+            self::delete_notification($observationid, $userid, $n->notification_id);
+        }
+
         // Allow Unenrolment.
         $dbdata = [
             'id' => $slotid,

--- a/tests/timeslot_notification_test.php
+++ b/tests/timeslot_notification_test.php
@@ -211,4 +211,79 @@ class timeslot_notification_test extends advanced_testcase {
             }
         }
     }
+
+    /**
+     * Tests if the notifications are deleted if a student unenrols from a timeslot
+     */
+    public function test_deleted_after_unenrol() {
+        global $DB;
+
+        $obid = $this->instance->id;
+
+        // Ensure unenrol is enabled.
+        $DB->update_record('observation', ['id' => $obid, 'students_self_unregister' => 1]);
+
+        // Create notification.
+        $this->setUser($this->observee);
+        \mod_observation\timeslot_manager::create_notification($this->instance->id, $this->slot1id, $this->observee->id,
+            (object) self::NOTIFY_DATA);
+
+        $notifications = \mod_observation\timeslot_manager::get_users_notifications($obid, $this->observee->id);
+        $this->assertEquals(1, count($notifications));
+
+        // User unenrols from timeslot.
+        \mod_observation\timeslot_manager::timeslot_unenrolment($obid, $this->slot1id, $this->observee->id);
+
+        // Ensure notifications are removed.
+        $notifications = \mod_observation\timeslot_manager::get_users_notifications($obid, $this->observee->id);
+        $this->assertEmpty($notifications);
+    }
+
+    public function test_deleted_after_kicked() {
+        global $DB;
+
+        $obid = $this->instance->id;
+
+        // Ensure unenrol is enabled.
+        $DB->update_record('observation', ['id' => $obid, 'students_self_unregister' => 1]);
+
+        // Create notification.
+        $this->setUser($this->observee);
+        \mod_observation\timeslot_manager::create_notification($this->instance->id, $this->slot1id, $this->observee->id,
+            (object) self::NOTIFY_DATA);
+
+        $notifications = \mod_observation\timeslot_manager::get_users_notifications($obid, $this->observee->id);
+        $this->assertEquals(1, count($notifications));
+
+        // User is kicked from timeslot.
+        \mod_observation\timeslot_manager::remove_observee($obid, $this->slot1id, $this->observer->id);
+
+        // Ensure notifications are removed.
+        $notifications = \mod_observation\timeslot_manager::get_users_notifications($obid, $this->observee->id);
+        $this->assertEmpty($notifications);
+    }
+
+    public function test_deleted_after_slot_deleted() {
+        global $DB;
+
+        $obid = $this->instance->id;
+
+        // Ensure unenrol is enabled.
+        $DB->update_record('observation', ['id' => $obid, 'students_self_unregister' => 1]);
+
+        // Create notification.
+        $this->setUser($this->observee);
+        \mod_observation\timeslot_manager::create_notification($this->instance->id, $this->slot1id, $this->observee->id,
+            (object) self::NOTIFY_DATA);
+
+        $notifications = \mod_observation\timeslot_manager::get_users_notifications($obid, $this->observee->id);
+        $this->assertEquals(1, count($notifications));
+
+        // Timeslot is deleted.
+        \mod_observation\timeslot_manager::delete_time_slot($obid, $this->slot1id, $this->observer->id);
+
+        // Ensure notifications are removed.
+        $notifications = \mod_observation\timeslot_manager::get_users_notifications($obid, $this->observee->id);
+        $this->assertEmpty($notifications);
+    }
 }

--- a/tests/unenrol_test.php
+++ b/tests/unenrol_test.php
@@ -99,7 +99,7 @@ class unenrol_test extends advanced_testcase {
         // Ensure unenrolment is enabled.
         $DB->update_record('observation', ['id' => $obid, 'students_self_unregister' => 1]);
 
-        // Observee 1 joins timeslot.
+        // Observee 1 joins timeslot and creates notification.
         \mod_observation\timeslot_manager::timeslot_signup($obid, $this->slotid, $this->observee->id);
 
         $this->preventResetByRollback();

--- a/timeslotjoining.php
+++ b/timeslotjoining.php
@@ -94,7 +94,7 @@ if ($signedupslot === false) {
     echo $OUTPUT->heading(get_string('yourtimeslot', 'observation'), 3);
     echo \mod_observation\table\timeslots\timeslots_display::assigned_timeslots_table($observation->id, $pageurl,
     \mod_observation\table\timeslots\timeslots_display::DISPLAY_MODE_OBSERVEE_REGISTERED, $USER->id);
-    
+
     echo $OUTPUT->heading(get_string('timeslotnotifications', 'observation'), 3);
     echo $OUTPUT->single_button(new moodle_url('/mod/observation/timeslotnotifications.php', ['id' => $id]),
         get_string('setuptimeslotnotifications', 'observation'), 'GET');

--- a/timeslotjoining.php
+++ b/timeslotjoining.php
@@ -94,7 +94,7 @@ if ($signedupslot === false) {
     echo $OUTPUT->heading(get_string('yourtimeslot', 'observation'), 3);
     echo \mod_observation\table\timeslots\timeslots_display::assigned_timeslots_table($observation->id, $pageurl,
     \mod_observation\table\timeslots\timeslots_display::DISPLAY_MODE_OBSERVEE_REGISTERED, $USER->id);
-
+    
     echo $OUTPUT->heading(get_string('timeslotnotifications', 'observation'), 3);
     echo $OUTPUT->single_button(new moodle_url('/mod/observation/timeslotnotifications.php', ['id' => $id]),
         get_string('setuptimeslotnotifications', 'observation'), 'GET');

--- a/version.php
+++ b/version.php
@@ -25,6 +25,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021052526;
+$plugin->version   = 2021052527;
 $plugin->requires  = 2021052500;
 $plugin->component = 'mod_observation';


### PR DESCRIPTION
Adds ability for users to setup notifications to remind them about a signed up time slot a specified time in advance (e.g. 1 hr or 1 day). 

Note - CRON jobs are not setup by default properly in the Docker moodle instance. To force the cron jobs to run manually, enter the docker container `./control web` and run `/usr/bin/php admin/cli/cron.php`. Under site adminstration -> scheduled tasks you can see the last time a scheduled task (cronjob) was run. 

Closes #49 

