### PR TITLE
[#121] Fix debugging warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
-name: Run all tests for Moodle 3.5+
+name: ci
 
 on: [push, pull_request]
 
 jobs:
-  workflow_group_35_plus_ci:
-    uses: catalyst/catalyst-moodle-workflows/.github/workflows/group-35-plus-ci.yml@main
+  ci:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    with:
+      disable_behat: true
+      disable_grunt: true
+      disable_phpcpd: true

--- a/lib.php
+++ b/lib.php
@@ -122,6 +122,10 @@ function observation_supports($feature) {
             return true;
         case FEATURE_BACKUP_MOODLE2:
             return true;
+        // Activity plugins default this to true, so explicity set to false.
+        // Since it is not supported by mod_observation.
+        case FEATURE_MOD_INTRO:
+            return false;
         default:
             return null;
     }

--- a/mod_form.php
+++ b/mod_form.php
@@ -79,12 +79,17 @@ class mod_observation_mod_form extends moodleform_mod {
         }
 
         // Editing, find the defaults and update the form values.
-        $obsdata = $DB->get_record('observation', array('id' => $obsid));
+        $obsdata = (object) $DB->get_record('observation', array('id' => $obsid));
 
-        $defaultvalues['observerins_editor']->text = $obsdata->observer_ins;
-        $defaultvalues['observerins_editor']->format = $obsdata->observer_ins_f;
-        $defaultvalues['observeeins_editor']->text = $obsdata->observee_ins;
-        $defaultvalues['observeeins_editor']->format = $obsdata->observee_ins_f;
+        $defaultvalues['observerins_editor'] = (object) [
+            'text' => $obsdata->observer_ins,
+            'format' => $obsdata->observer_ins_f
+        ];
+
+        $defaultvalues['observeeins_editor'] = (object) [
+            'text' => $obsdata->observee_ins,
+            'format' => $obsdata->observee_ins_f
+        ];
 
         return;
     }

--- a/version.php
+++ b/version.php
@@ -30,3 +30,4 @@ $plugin->release   = 2021052533;
 $plugin->requires  = 2018051700;
 $plugin->component = 'mod_observation';
 $plugin->maturity = MATURITY_STABLE;
+$plugin->supported = [39, 311];


### PR DESCRIPTION
**Changes**
- Updated `data_preprocessing` function so that it creates the objects rather than assuming they are there (which they weren't)
- Disable mod intro explicitly. It was defaulting to enabled, but since it didn't send an intro there were debugging warnings about missing introformat. It doesn't have one so disabled it.
- Updated CI - was using old reusable workflows CI and phpcpd was giving some weird errors and wasn't able to disable it. Updated the CI and was able to disable it.

Closes #121 