### PR TITLE
[#129] Handle users being removed from timeslots when processing noti…

### DIFF
--- a/classes/timeslot_manager.php
+++ b/classes/timeslot_manager.php
@@ -665,13 +665,18 @@ class timeslot_manager {
         foreach ($notifications as $n) {
             $notifytime = $n->start_time - $n->time_before;
 
-            if ($notifytime < time()) {
-                // Process it !
-                self::send_reminder_message($n->obs_id, $n->timeslot_id, $n->userid);
-
-                // Delete notification record.
-                $DB->delete_records('observation_notifications', ['id' => $n->notification_id]);
+            // Not ready yet - skip.
+            if (time() < $notifytime) {
+                continue;
             }
+
+            // If user is still linked to the timeslot, send the reminder message.
+            if (!empty($n->userid)) {
+                self::send_reminder_message($n->obs_id, $n->timeslot_id, $n->userid);
+            }
+
+            // Delete the record.
+            $DB->delete_records('observation_notifications', ['id' => $n->notification_id]);
         }
     }
 

--- a/tests/backup_test.php
+++ b/tests/backup_test.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_observation;
+
+use advanced_testcase;
+
 /**
  * Unit tests for observation backups.
  *
@@ -22,6 +26,8 @@
  * @copyright   Catalyst IT Australia
  * @author      Matthew Hilton
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers      \backup_observation_activity_task
+ * @covers      \restore_observation_activity_task
  */
 class backup_test extends advanced_testcase {
     /**

--- a/tests/observation_point_test.php
+++ b/tests/observation_point_test.php
@@ -14,15 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for the observation point manager class.
- *
- * @package    mod_observation
- * @category   test
- * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
- * @author Matthew Hilton <mj.hilton@outlook.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_observation;
+
+use advanced_testcase;
 
 /**
  * Unit tests for the observation point manager class.
@@ -32,6 +26,7 @@
  * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
  * @author     Matthew Hilton <mj.hilton@outlook.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \mod_observation\observation_manager
  */
 class observation_point_test extends advanced_testcase {
 

--- a/tests/observation_session_test.php
+++ b/tests/observation_session_test.php
@@ -14,15 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for the observation session class.
- *
- * @package    mod_observation
- * @category   test
- * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
- * @author Matthew Hilton <mj.hilton@outlook.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_observation;
+
+use advanced_testcase;
 
 /**
  * Unit tests for the observation session manager class.
@@ -32,6 +26,7 @@
  * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
  * @author     Matthew Hilton <mj.hilton@outlook.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \mod_observation\observation_manager
  */
 class observation_session_test extends advanced_testcase {
 

--- a/tests/provider_test.php
+++ b/tests/provider_test.php
@@ -14,30 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for the block_community implementation of the privacy API.
- *
- * @package   mod_observation
- * @copyright  Catalyst IT
- * @author Matthew Hilton <matthewhilton@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_observation;
 
-defined('MOODLE_INTERNAL') || die();
-
-use \core_privacy\local\metadata\collection;
-use \core_privacy\local\request\writer;
-use \core_privacy\local\request\approved_contextlist;
-use \mod_observation\privacy\provider;
+use core_privacy\local\metadata\collection;
+use core_privacy\local\request\writer;
+use core_privacy\local\request\approved_contextlist;
+use mod_observation\privacy\provider;
 
 /**
  * Unit tests for the mod_observation implementation of the privacy API.
  *
  * @copyright  Catalyst IT
+ * @package mod_observation
  * @author Matthew Hilton <matthewhilton@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \mod_observation\privacy\provider
  */
-class mod_observation_privacy_testcase extends \core_privacy\tests\provider_testcase {
+class provider_test extends \core_privacy\tests\provider_testcase {
     /**
      * Set up for tests.
      */
@@ -359,7 +352,7 @@ class mod_observation_privacy_testcase extends \core_privacy\tests\provider_test
         ]);
 
         // Export the user data for this user.
-        $cmcontext = context_module::instance($this->instance->cmid);
+        $cmcontext = \context_module::instance($this->instance->cmid);
         $writer = writer::with_context($cmcontext);
         $contextlist = new approved_contextlist($this->observee, 'mod_observation' , [$cmcontext->id]);
 

--- a/tests/timeslot_joining_test.php
+++ b/tests/timeslot_joining_test.php
@@ -14,15 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for the observation timeslot joining.
- *
- * @package    mod_observation
- * @category   test
- * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
- * @author Jack Kepper <Jack@Kepper.net>, Matthew Hilton <mj.hilton@outlook.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_observation;
+
+use advanced_testcase;
 
 /**
  * Unit tests for the observation timeslot joining.
@@ -32,6 +26,7 @@
  * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
  * @author Jack Kepper <Jack@Kepper.net>, Matthew Hilton <mj.hilton@outlook.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \mod_observation\timeslot_manager
  */
 class timeslot_joining_test extends advanced_testcase {
 

--- a/tests/timeslot_notification_test.php
+++ b/tests/timeslot_notification_test.php
@@ -286,4 +286,26 @@ class timeslot_notification_test extends advanced_testcase {
         $notifications = \mod_observation\timeslot_manager::get_users_notifications($obid, $this->observee->id);
         $this->assertEmpty($notifications);
     }
+
+    /**
+     * Tests that process_notifications handles correctly a notification with no observee to send it to.
+     * In this case, it should just ignore it and delete the notification processing record.
+     */
+    public function test_process_notifications_after_user_removed() {
+        global $DB;
+
+        // Create notification.
+        $this->setUser($this->observee);
+        \mod_observation\timeslot_manager::create_notification($this->instance->id, $this->slot1id, $this->observee->id,
+            (object) self::NOTIFY_DATA);
+
+        $this->assertEquals(1, $DB->count_records('observation_notifications'));
+
+        // Remove them from the timeslot.
+        \mod_observation\timeslot_manager::remove_observee($this->instance->id, $this->slot1id, $this->observee->id);
+        
+        // Process their notifications. This should just remove the notification, since the user is not longer assigned to the timeslot.
+        \mod_observation\timeslot_manager::process_notifications();
+        $this->assertEquals(0, $DB->count_records('observation_notifications'));
+    }
 }

--- a/tests/timeslot_notification_test.php
+++ b/tests/timeslot_notification_test.php
@@ -14,15 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for the observation timeslot joining.
- *
- * @package    mod_observation
- * @category   test
- * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
- * @author Matthew Hilton <mj.hilton@outlook.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_observation;
+
+use advanced_testcase;
 
 /**
  * Unit tests for observation timeslot notifications.
@@ -32,6 +26,7 @@
  * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
  * @author Matthew Hilton <mj.hilton@outlook.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \mod_observation\timeslot_manager
  */
 class timeslot_notification_test extends advanced_testcase {
 
@@ -303,8 +298,9 @@ class timeslot_notification_test extends advanced_testcase {
 
         // Remove them from the timeslot.
         \mod_observation\timeslot_manager::remove_observee($this->instance->id, $this->slot1id, $this->observee->id);
-        
-        // Process their notifications. This should just remove the notification, since the user is not longer assigned to the timeslot.
+
+        // Process their notifications. This should just remove the notification,
+        // since the user is not longer assigned to the timeslot.
         \mod_observation\timeslot_manager::process_notifications();
         $this->assertEquals(0, $DB->count_records('observation_notifications'));
     }

--- a/tests/timeslots_test.php
+++ b/tests/timeslots_test.php
@@ -14,15 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for timeslots.
- *
- * @package    mod_observation
- * @category   test
- * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
- * @author Matthew Hilton <mj.hilton@outlook.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_observation;
+
+use advanced_testcase;
 
 /**
  * Unit tests for timeslots.
@@ -32,6 +26,7 @@
  * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
  * @author     Matthew Hilton <mj.hilton@outlook.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \mod_observation\timeslot_manager
  */
 class timeslots_test extends advanced_testcase {
 
@@ -224,7 +219,7 @@ class timeslots_test extends advanced_testcase {
      * Creates data for valid interval timeslot
      */
     private function create_valid_interval_timeslot() {
-        $data = new stdClass();
+        $data = new \stdClass();
 
         $data->interval_amount = 30;
         // In form the multiplier is a string, so simulate that here.

--- a/tests/unenrol_test.php
+++ b/tests/unenrol_test.php
@@ -14,15 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Unit tests for the observation session class.
- *
- * @package    mod_observation
- * @category   test
- * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
- * @author Jack Kepper <Jack@Kepper.net>, Matthew Hilton <mj.hilton@outlook.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace mod_observation;
+
+use advanced_testcase;
 
 /**
  * Unit tests for unenrollment functions.
@@ -32,6 +26,7 @@
  * @copyright  Matthew Hilton, Celine Lindeque, Jack Kepper, Jared Hungerford
  * @author     Jack Kepper <Jack@Kepper.net>, Matthew Hilton <mj.hilton@outlook.com>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \mod_observation\timeslot_manager
  */
 class unenrol_test extends advanced_testcase {
 


### PR DESCRIPTION
Closes #129 

- If a user is removed from a timeslot before the notification is processed, the notification is just deleted (since it does not make any sense to keep it)
- Added a unit test to cover this scenario (test was failing before implemented fix, now it passes)

To Do:
- [ ] Cherry pick to `main` branch -> https://github.com/catalyst/moodle-mod_observation/pull/131