### PR TITLE
Issue #132: ensure child records are deleted with their parents

### DIFF
--- a/classes/observation_manager.php
+++ b/classes/observation_manager.php
@@ -216,6 +216,7 @@ class observation_manager {
 
         $transaction = $DB->start_delegated_transaction();
 
+        $DB->delete_records('observation_point_responses', ['obs_pt_id' => $obpointid]);
         $DB->delete_records('observation_points', ['id' => $obpointid, 'obs_id' => $observationid]);
 
         // Shuffle those above down.

--- a/classes/session_manager.php
+++ b/classes/session_manager.php
@@ -303,4 +303,16 @@ class session_manager {
             'finish_time' => time()]);
         return;
     }
+
+    /**
+     * Deletes observation session
+     * @param int $observationid ID of the observation instance
+     * @param int $sessionid ID of the observation session to delete
+     */
+    public static function delete_observation_session(int $observationid, int $sessionid) {
+        global $DB;
+
+        $DB->delete_records('observation_point_responses', ['obs_ses_id' => $sessionid]);
+        $DB->delete_records('observation_sessions', ['id' => $sessionid, 'obs_id' => $observationid]);
+    }
 }

--- a/classes/timeslot_manager.php
+++ b/classes/timeslot_manager.php
@@ -155,6 +155,7 @@ class timeslot_manager {
             self::send_cancellation_message($observationid, $slotid, $timeslot->observee_id, $actioninguserid);
         }
 
+        $DB->delete_records('observation_notifications', ['timeslot_id' => $slotid]);
         $DB->delete_records('observation_timeslots', ['id' => $slotid, 'obs_id' => $observationid]);
     }
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -108,5 +108,31 @@ function xmldb_observation_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2021052533, 'observation');
     }
 
+    if ($oldversion < 2024052801) {
+        // Clean up any orphan records.
+        $obssqlwhere = 'obs_id NOT IN (SELECT id FROM {observation})';
+
+        // Time slots.
+        $DB->delete_records_select('observation_timeslots', $obssqlwhere);
+
+        // Notifications.
+        $sqlwhere = 'timeslot_id NOT IN (SELECT id FROM {observation_timeslots})';
+        $DB->delete_records_select('observation_notifications', $sqlwhere);
+
+        // Sessions.
+        $DB->delete_records_select('observation_sessions', $obssqlwhere);
+
+        // Points.
+        $DB->delete_records_select('observation_points', $obssqlwhere);
+
+        // Point responses.
+        $sqlwhere = 'obs_pt_id NOT IN (SELECT id FROM {observation_points})
+                     OR obs_ses_id NOT IN (SELECT id FROM {observation_sessions})';
+        $DB->delete_records_select('observation_point_responses', $sqlwhere);
+
+        // Observation savepoint reached.
+        upgrade_mod_savepoint(true, 2024052801, 'observation');
+    }
+
     return true;
 }

--- a/tests/observation_point_test.php
+++ b/tests/observation_point_test.php
@@ -90,6 +90,8 @@ class observation_point_test extends advanced_testcase {
      * Tests CRUD operations for observation point with expected data.
      */
     public function test_crud_expected () {
+        global $DB;
+
         $data = self::VALID_DATA;
         $data['obs_id'] = $this->instance->id;
 
@@ -137,6 +139,9 @@ class observation_point_test extends advanced_testcase {
         $this->assertTrue(in_array($editeddata->title, array_column($returndata, 'title')));
         $this->assertFalse(in_array($data['title'], array_column($returndata, 'title')));
 
+        $responses = $DB->get_records('observation_point_responses', ['obs_pt_id' => $returnedpoint->id]);
+        $this->assertCount(1, $responses);
+
         // Delete point.
         \mod_observation\observation_manager::delete_observation_point($this->instance->id, $returnedpoint->id);
 
@@ -144,6 +149,10 @@ class observation_point_test extends advanced_testcase {
         $returndata = \mod_observation\observation_manager::get_observation_points($this->instance->id);
 
         $this->assertEmpty($returndata);
+
+        // Confirm response also deleted.
+        $responses = $DB->get_records('observation_point_responses', ['obs_pt_id' => $returnedpoint->id]);
+        $this->assertCount(0, $responses);
 
         // Cannot access point as no longer exists (throws exception).
         $this->expectException('dml_exception');

--- a/tests/observation_session_test.php
+++ b/tests/observation_session_test.php
@@ -285,4 +285,39 @@ class observation_session_test extends advanced_testcase {
         \mod_observation\session_manager::start_session($obid, $oberid, $this->observee->id);
         \mod_observation\session_manager::start_session($obid, $oberid, $this->observee2->id);
     }
+
+    /**
+     * Tests CRUD operations for observation point with expected data.
+     */
+    public function test_crud_expected() {
+        global $DB;
+
+        // Create session and submit point response.
+        $sessionid = $this->create_session();
+        $response = (object)self::VALID_RESPONSE;
+        \mod_observation\observation_manager::submit_point_response($sessionid, $this->pointid1, $response);
+
+        $responses = $DB->get_records('observation_point_responses', ['obs_pt_id' => $this->pointid1]);
+        $this->assertCount(1, $responses);
+
+        // Delete session and test response is also deleted.
+        \mod_observation\session_manager::delete_observation_session($this->instance->id, $sessionid);
+
+        $responses = $DB->get_records('observation_point_responses', ['obs_pt_id' => $this->pointid1]);
+        $this->assertCount(0, $responses);
+
+        // Create another session and submit point response.
+        $sessionid = $this->create_session();
+        $response = (object)self::VALID_RESPONSE;
+        \mod_observation\observation_manager::submit_point_response($sessionid, $this->pointid1, $response);
+
+        $responses = $DB->get_records('observation_point_responses', ['obs_pt_id' => $this->pointid1]);
+        $this->assertCount(1, $responses);
+
+        // Delete point and test related responses are deleted.
+        \mod_observation\observation_manager::delete_observation_point($this->instance->id, $this->pointid1);
+
+        $responses = $DB->get_records('observation_point_responses', ['obs_pt_id' => $this->pointid1]);
+        $this->assertCount(0, $responses);
+    }
 }

--- a/tests/timeslot_notification_test.php
+++ b/tests/timeslot_notification_test.php
@@ -111,6 +111,19 @@ class timeslot_notification_test extends advanced_testcase {
 
         $notifys = \mod_observation\timeslot_manager::get_users_notifications($this->instance->id, $this->observee->id);
         $this->assertEquals(0, count($notifys));
+
+        // Create a different notification.
+        \mod_observation\timeslot_manager::create_notification($this->instance->id, $this->slot2id, $this->observee2->id,
+            (object) self::NOTIFY_DATA);
+
+        $notifys = \mod_observation\timeslot_manager::get_users_notifications($this->instance->id, $this->observee2->id);
+        $this->assertEquals(1, count($notifys));
+
+        // Delete timeslot 2 and check notification is also deleted.
+        \mod_observation\timeslot_manager::delete_time_slot($this->instance->id, $this->slot2id, $this->observer->id);
+
+        $notifys = \mod_observation\timeslot_manager::get_users_notifications($this->instance->id, $this->observee2->id);
+        $this->assertEquals(0, count($notifys));
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022041900;
-$plugin->release   = 2022041900;
+$plugin->version   = 2024052801;
+$plugin->release   = 2024052801;
 $plugin->requires  = 2022041900;
 $plugin->component = 'mod_observation';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
These changes ensure child records are deleted when their parents are and also does a clean up of current orphaned records.
Further explanation in issue #132

Internal WR: https://wrms.catalyst.net.nz/wr.php?request_id=426153