### PR TITLE
Issue #134: remove completionpassgrade from settings

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -59,6 +59,11 @@ class mod_observation_mod_form extends moodleform_mod {
         // Footer.
         $this->standard_coursemodule_elements();
         $this->add_action_buttons();
+
+        // Observations don't have a grade to pass setting, so remove this element.
+        if ($mform->elementExists('completionpassgrade')) {
+            $mform->removeElement('completionpassgrade');
+        }
     }
 
     /**


### PR DESCRIPTION
There is no grade to pass setting for observations so the completionpassgrade option is not needed and presents an error if the user tries to turn it on and save the activity.