### PR TITLE
Fix: remove failing unit test added in issue #132

### DIFF
--- a/tests/observation_point_test.php
+++ b/tests/observation_point_test.php
@@ -139,9 +139,6 @@ class observation_point_test extends advanced_testcase {
         $this->assertTrue(in_array($editeddata->title, array_column($returndata, 'title')));
         $this->assertFalse(in_array($data['title'], array_column($returndata, 'title')));
 
-        $responses = $DB->get_records('observation_point_responses', ['obs_pt_id' => $returnedpoint->id]);
-        $this->assertCount(1, $responses);
-
         // Delete point.
         \mod_observation\observation_manager::delete_observation_point($this->instance->id, $returnedpoint->id);
 
@@ -149,10 +146,6 @@ class observation_point_test extends advanced_testcase {
         $returndata = \mod_observation\observation_manager::get_observation_points($this->instance->id);
 
         $this->assertEmpty($returndata);
-
-        // Confirm response also deleted.
-        $responses = $DB->get_records('observation_point_responses', ['obs_pt_id' => $returnedpoint->id]);
-        $this->assertCount(0, $responses);
 
         // Cannot access point as no longer exists (throws exception).
         $this->expectException('dml_exception');


### PR DESCRIPTION
As part of issue #132 / PR #133 2 new unit test cases were added to observation_session_test.php test_crud_expected() which were failing due to that test case not having a point response.

These were probably left over as the tests were moved over to observation_session_test.php test_crud_expected() https://github.com/catalyst/moodle-mod_observation/commit/429018c0aef22b53655fe8b03cdb0128b4f89811#diff-b5b912572b2cce701bb5fe3363f17dde782630b765057469757f64c825de6b36R309-R321