### PR TITLE
Issue #138: Ensure classes do not use dynamic properties

### DIFF
--- a/classes/table/timeslots/timeslots_table.php
+++ b/classes/table/timeslots/timeslots_table.php
@@ -38,6 +38,9 @@ require_once($CFG->libdir . '/tablelib.php');
  */
 class timeslots_table extends \table_sql implements \renderable {
 
+    /** @var int Display mode for table. */
+    public $displaymode = 0;
+
     /**
      * Constructs the table and defines how the data from the SQL query is displayed
      * @param string $uniqueid ID that uniquely identifies this element on the HTML page

--- a/classes/table/viewpoints/viewpoints_table.php
+++ b/classes/table/viewpoints/viewpoints_table.php
@@ -38,6 +38,13 @@ require_once($CFG->libdir . '/tablelib.php');
  */
 class viewpoints_table extends \table_sql implements \renderable {
 
+
+    /** @var context\system System context. */
+    protected $context = 0;
+
+    /** @var int Display mode for table. */
+    protected $displaymode = 0;
+
     /**
      * Constructs the table and defines how the data from the SQL query is displayed
      * @param string $uniqueid ID that uniquely identifies this element on the HTML page

--- a/classes/table/viewsessions/viewsessions_table.php
+++ b/classes/table/viewsessions/viewsessions_table.php
@@ -38,6 +38,9 @@ require_once($CFG->libdir . '/tablelib.php');
  */
 class viewsessions_table extends \table_sql implements \renderable {
 
+    /** @var context\system System context. */
+    protected $context = 0;
+
     /**
      * Constructs the table and defines how the data from the SQL query is displayed
      * @param string $uniqueid ID that uniquely identifies this element on the HTML page


### PR DESCRIPTION
**Description:** Dynamic properties were deprecated in PHP 8.2:

https://php.watch/versions/8.2/dynamic-properties-deprecated

This PR updates the classes that use dynamic properties. Since this is a minor change and doesn't cause any backward compatibility issues, we merge into MOODLE_400_STABLE