### PR TITLE
[#140] properly save and load html instructions

### DIFF
--- a/assignstudents.php
+++ b/assignstudents.php
@@ -40,7 +40,7 @@ if ($mode !== 'randomassign') {
         'invalidqueryparam',
         'error',
         null,
-        $a = array('expected' => 'mode to be \'randomassign\'', 'actual' => $mode));
+        $a = ['expected' => 'mode to be \'randomassign\'', 'actual' => $mode]);
 }
 
 require_login($course, true, $cm);

--- a/backup/moodle2/backup_observation_stepslib.php
+++ b/backup/moodle2/backup_observation_stepslib.php
@@ -43,14 +43,14 @@ class backup_observation_activity_structure_step extends backup_activity_structu
             'observee_ins',
             'observee_ins_f',
             'students_self_unregister',
-            'marking_type'
+            'marking_type',
         ]);
 
         $notifications = new backup_nested_element('notifications');
 
         $notification = new backup_nested_element('notification', ['id'], [
             'timeslot_id',
-            'time_before'
+            'time_before',
         ]);
 
         $points = new backup_nested_element('points');
@@ -63,7 +63,7 @@ class backup_observation_activity_structure_step extends backup_activity_structu
             'ins_f',
             'max_grade',
             'res_type',
-            'file_size'
+            'file_size',
         ]);
 
         $responses = new backup_nested_element('responses');
@@ -75,7 +75,7 @@ class backup_observation_activity_structure_step extends backup_activity_structu
             'response',
             'ex_comment',
             'timecreated',
-            'timemodified'
+            'timemodified',
         ]);
 
         $sessions = new backup_nested_element('sessions');
@@ -87,7 +87,7 @@ class backup_observation_activity_structure_step extends backup_activity_structu
             'state',
             'start_time',
             'finish_time',
-            'ex_comment'
+            'ex_comment',
         ]);
 
         $timeslots = new backup_nested_element('timeslots');
@@ -99,7 +99,7 @@ class backup_observation_activity_structure_step extends backup_activity_structu
             'observer_id',
             'observee_id',
             'observer_event_id',
-            'observee_event_id'
+            'observee_event_id',
         ]);
 
         // Timeslots tree.

--- a/classes/calendar_signup.php
+++ b/classes/calendar_signup.php
@@ -66,7 +66,7 @@ class calendar_signup {
 
             return (object) [
                 "daynum" => $daynum,
-                "events" => []
+                "events" => [],
             ];
         }, $monthdays, array_keys($monthdays));
 
@@ -117,7 +117,7 @@ class calendar_signup {
             'monthname' => date('F', mktime(0, 0, 0, $month, 10)),
             'nextbtn' => $nextmonthbtn,
             'prevbtn' => $prevmonthbtn,
-            'entries' => $weeks
+            'entries' => $weeks,
         ];
 
         return $OUTPUT->render_from_template('mod_observation/calendar_signup', $templatedata);

--- a/classes/form/notificationeditor.php
+++ b/classes/form/notificationeditor.php
@@ -57,7 +57,7 @@ class notificationeditor extends \moodleform {
         $intervalselector = [
             $mform->createElement('text', 'interval_amount'),
             $mform->createElement('select', 'interval_multiplier', '', $options),
-            $mform->createElement('submit', 'submit_btn', get_string('create', 'observation'))
+            $mform->createElement('submit', 'submit_btn', get_string('create', 'observation')),
         ];
 
         $mform->addGroup($intervalselector, 'select_group', get_string('receivenotification', 'observation'), null, false);

--- a/classes/form/pointeditor.php
+++ b/classes/form/pointeditor.php
@@ -48,12 +48,12 @@ class pointeditor extends \moodleform {
         $mform->addElement('header', 'gradingsettings', get_string('grading', 'observation'));
 
         // Point type selection.
-        $radioarray = array();
+        $radioarray = [];
         $radioarray[] = $mform->createElement('radio', 'res_type', '', get_string('textinputtype', 'observation'), 0);
         $radioarray[] = $mform->createElement('radio', 'res_type', '', get_string('passfailtype', 'observation'), 1);
         $radioarray[] = $mform->createElement('radio', 'res_type', '', get_string('evidencetype', 'observation'), 2);
 
-        $mform->addGroup($radioarray, 'radioar', get_string('obpointtype', 'observation'), array(' '), false);
+        $mform->addGroup($radioarray, 'radioar', get_string('obpointtype', 'observation'), [' '], false);
         $mform->setDefault('type', 0);
 
         // Evidence file size.

--- a/classes/form/pointeditor.php
+++ b/classes/form/pointeditor.php
@@ -70,7 +70,7 @@ class pointeditor extends \moodleform {
 
         // Grading instructions.
         $mform->addElement('editor', 'ins', get_string('gradinginstructions', 'observation'));
-        $mform->setType('ins', PARAM_TEXT);
+        $mform->setType('ins', PARAM_RAW); // Editors must be PARAM_RAW.
         $mform->addRule('ins', get_string('required', 'observation'), 'required', null, 'client');
 
         // Max / default grade selection.

--- a/classes/form/pointmarking.php
+++ b/classes/form/pointmarking.php
@@ -53,7 +53,7 @@ class pointmarking extends \moodleform {
 
         // Observation point information.
         $instext = $prefill['ins'];
-        $insformat = $prefill['ins_f'];
+        $insformat = (int) $prefill['ins_f'];
 
         $mform->addElement('static', 'instructions', get_string('gradinginstructions', 'observation'),
             format_text($instext, $insformat));

--- a/classes/form/pointmarking.php
+++ b/classes/form/pointmarking.php
@@ -68,10 +68,10 @@ class pointmarking extends \moodleform {
                 break;
             // Pass/Fail type.
             case \mod_observation\observation_manager::INPUT_PASSFAIL:
-                $radioarray = array();
+                $radioarray = [];
                 $radioarray[] = $mform->createElement('radio', 'response', '', get_string('pass', 'observation'), 'Pass');
                 $radioarray[] = $mform->createElement('radio', 'response', '', get_string('fail', 'observation'), 'Fail');
-                $mform->addGroup($radioarray, 'radioar', get_string('passfailtype', 'observation'), array(' '), false);
+                $mform->addGroup($radioarray, 'radioar', get_string('passfailtype', 'observation'), [' '], false);
                 $mform->setType('response', PARAM_TEXT);
                 $mform->addRule('radioar', get_string('required', 'observation'), 'required', null, 'client');
                 break;
@@ -79,8 +79,8 @@ class pointmarking extends \moodleform {
                 // Image upload here.
                 $maxbytes = $prefill['file_size'];
                 $mform->addElement('filemanager', 'response', get_string('evidenceupload', 'observation'), null,
-                    array('subdirs' => 0, 'maxbytes' => $maxbytes, 'areamaxbytes' => $maxbytes, 'maxfiles' => 1,
-                          'accepted_types' => 'audio,video,image,document'));
+                    ['subdirs' => 0, 'maxbytes' => $maxbytes, 'areamaxbytes' => $maxbytes, 'maxfiles' => 1,
+                          'accepted_types' => 'audio,video,image,document']);
                 $mform->setType('response', PARAM_INT);
                 $mform->addRule('response', get_string('required', 'observation'), 'required', null, 'client');
                 break;

--- a/classes/form/startsession.php
+++ b/classes/form/startsession.php
@@ -60,9 +60,9 @@ class startsession extends \moodleform {
             $finalusers[$u->id] = fullname($u);
         }
 
-        $options = array(
+        $options = [
             'multiple' => false,
-        );
+        ];
 
         $mform->addElement('text', 'observername', get_string('observer', 'observation'));
         $mform->setDefault('observername', fullname($USER));

--- a/classes/form/timesloteditor.php
+++ b/classes/form/timesloteditor.php
@@ -75,7 +75,7 @@ class timesloteditor extends \moodleform {
 
             $intervalselector = [
                 $mform->createElement('text', 'interval_amount'),
-                $mform->createElement('select', 'interval_multiplier', '', $options)
+                $mform->createElement('select', 'interval_multiplier', '', $options),
             ];
             $mform->addGroup($intervalselector, 'interval_select_group', get_string('repeatevery', 'observation'), null, false);
             $mform->disabledIf('interval_select_group', 'enable_interval');
@@ -97,10 +97,10 @@ class timesloteditor extends \moodleform {
         foreach ($users as $user) {
             $finalusers[$user->id] = fullname($user);
         }
-        $options = array(
+        $options = [
             'multiple' => false,
             'noselectionstring' => get_string('allareas', 'search'),
-        );
+        ];
         $mform->addElement('header', 'selecting_observer', get_string('selecting_observer', 'observation'));
         $mform->addElement('autocomplete', 'observer_id', get_string('teacher', 'observation'), $finalusers, $options);
 

--- a/classes/form/upcomingfilter.php
+++ b/classes/form/upcomingfilter.php
@@ -58,7 +58,7 @@ class upcomingfilter extends \moodleform {
         $intervalselector = [
             $mform->createElement('text', 'interval_amount'),
             $mform->createElement('select', 'interval_multiplier', '', $options),
-            $mform->createElement('submit', 'submit_btn', $buttontext)
+            $mform->createElement('submit', 'submit_btn', $buttontext),
         ];
 
         // Interval selector block.

--- a/classes/instructions.php
+++ b/classes/instructions.php
@@ -46,7 +46,7 @@ class instructions {
      * @return string formatted html to be displays encoded as a string
      **/
     public static function observation_instructions(?string $heading, ?string $bodytext, ?int $bodyformat, int $headinglevel = 3,
-        string $defaultmessage = null): string {
+        ?string $defaultmessage = null): string {
 
         global $OUTPUT;
         // Can't set function values as default parameters, so do it here.

--- a/classes/observation_manager.php
+++ b/classes/observation_manager.php
@@ -210,7 +210,7 @@ class observation_manager {
             "obs_id = :obsid AND list_order > :listorder",
             [
                 'obsid' => $observationid,
-                'listorder' => $currentpoint->list_order
+                'listorder' => $currentpoint->list_order,
             ]
         );
 
@@ -225,7 +225,7 @@ class observation_manager {
                 'observation_points',
                 [
                     'id' => $pointabove->id,
-                    'list_order' => $pointabove->list_order - 1
+                    'list_order' => $pointabove->list_order - 1,
                 ]
             );
         }
@@ -290,7 +290,7 @@ class observation_manager {
         $DB->update_record('observation_points',
         [
             'id' => $targetpoint->id,
-            'list_order' => $newordering
+            'list_order' => $newordering,
         ]);
 
         // Reduce the direction to a unit vector (e.g. 5 -> 1 and -5 -> -1).
@@ -301,7 +301,7 @@ class observation_manager {
             $DB->update_record('observation_points',
             [
                 'id' => $e->id,
-                'list_order' => $e->list_order - $reductionamount
+                'list_order' => $e->list_order - $reductionamount,
             ]);
         }, $affectedpoints);
 
@@ -368,7 +368,7 @@ class observation_manager {
             'grade_given' => $data->grade_given,
             'response' => $data->response,
             'ex_comment' => $data->ex_comment,
-            'timemodified' => time()
+            'timemodified' => time(),
         ];
 
         if ($existingresponse === false) {
@@ -447,7 +447,7 @@ class observation_manager {
                 $item->title,
                 $item->response,
                 $item->grade_given,
-                $item->ex_comment
+                $item->ex_comment,
             ];
         }, $pointsandresponses);
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -48,7 +48,7 @@ class provider implements
      * @param   collection     $collection The initialised collection to add items to.
      * @return  collection     A listing of user data stored through this system.
      */
-    public static function get_metadata(collection $collection) : collection {
+    public static function get_metadata(collection $collection): collection {
 
         $collection->add_subsystem_link(
             'core_files',
@@ -75,7 +75,7 @@ class provider implements
                 'response' => 'privacy:metadata:observation_point_responses:response',
                 'ex_comment' => 'privacy:metadata:observation_point_responses:ex_comment',
                 'timecreated' => 'privacy:metadata:observation_point_responses:timecreated',
-                'timemodified' => 'privacy:metadata:observation_point_responses:timemodified'
+                'timemodified' => 'privacy:metadata:observation_point_responses:timemodified',
              ],
             'privacy:metadata:observation_point_responses'
         );
@@ -113,7 +113,7 @@ class provider implements
       * @param int $userid The user to search.
       * @return contextlist $contextlist The contextlist containing the list of contexts used in this plugin.
       */
-    public static function get_contexts_for_userid(int $userid) : contextlist {
+    public static function get_contexts_for_userid(int $userid): contextlist {
         $contextlist = new contextlist();
 
         $params = [
@@ -208,7 +208,7 @@ class provider implements
             // Get all timeslot records where the user is a part of them.
             $timeslots = $DB->get_records_select('observation_timeslots', 'observer_id = :userid1 OR observee_id = :userid2', [
                 'userid1' => $userid,
-                'userid2' => $userid
+                'userid2' => $userid,
             ]);
 
             $data->timeslots = $timeslots;
@@ -249,7 +249,7 @@ class provider implements
             // Delete all timeslot records where the user is a part of them.
             $DB->delete_records_select('observation_timeslots', 'observer_id = :userid1 OR observee_id = :userid2', [
                 'userid1' => $userid,
-                'userid2' => $userid
+                'userid2' => $userid,
             ]);
         }
     }
@@ -291,7 +291,7 @@ class provider implements
             // Delete all timeslot records where the user is a part of them.
             $DB->delete_records_select('observation_timeslots', 'observer_id = :userid1 OR observee_id = :userid2', [
                 'userid1' => $userid,
-                'userid2' => $userid
+                'userid2' => $userid,
             ]);
         }
     }
@@ -301,7 +301,7 @@ class provider implements
      *
      * @param   context                 $context   The specific context to delete data for.
      */
-    public static function delete_data_for_all_users_in_context (\context $context) {
+    public static function delete_data_for_all_users_in_context(\context $context) {
         global $DB;
 
         if ($context->contextlevel != CONTEXT_MODULE) {

--- a/classes/session_manager.php
+++ b/classes/session_manager.php
@@ -93,7 +93,7 @@ class session_manager {
             'observee_id' => $observeeid,
             'observer_id' => $observerid,
             'state' => self::SESSION_INPROGRESS,
-            'start_time' => time()
+            'start_time' => time(),
         ];
 
         return $DB->insert_record('observation_sessions', $data, true);
@@ -116,7 +116,7 @@ class session_manager {
             'ex_comment' => $sessiondata->ex_comment,
             'state' => $sessiondata->state,
             'observee' => $sessiondata->observee_id,
-            'observer' => $sessiondata->observer_id
+            'observer' => $sessiondata->observer_id,
         ];
     }
 
@@ -174,7 +174,7 @@ class session_manager {
 
         return [
             'total' => array_sum($givengrades),
-            'max' => array_sum($maxgrades)
+            'max' => array_sum($maxgrades),
         ];
     }
 
@@ -275,7 +275,7 @@ class session_manager {
             'gradetype' => 1,
             'grademax' => $maxgrade,
             'grademin' => $mingrade,
-            'itemname' => $cm->name . ' - ' . get_string('gradeitemname', 'observation')
+            'itemname' => $cm->name . ' - ' . get_string('gradeitemname', 'observation'),
         ];
 
         $grade = [
@@ -285,7 +285,7 @@ class session_manager {
             'datesubmitted' => time(),
             'dategraded' => time(),
             'feedbackformat' => FORMAT_PLAIN,
-            'feedback' => $sessioninfo['ex_comment']
+            'feedback' => $sessioninfo['ex_comment'],
         ];
 
         return \grade_update('mod/observation', $course->id, 'mod', 'observation', $obid, 0, $grade, $params);

--- a/classes/table/notifications/notifications_display.php
+++ b/classes/table/notifications/notifications_display.php
@@ -48,7 +48,7 @@ class notifications_display {
             'fields' => 'obn.id AS id, time_before, start_time',
             'from' => '{observation_notifications} obn LEFT JOIN {observation_timeslots} ot ON obn.timeslot_id = ot.id',
             'where' => 'ot.observee_id = :userid AND ot.obs_id = :obsid',
-            'params' => ['userid' => $userid, 'obsid' => $observationid]
+            'params' => ['userid' => $userid, 'obsid' => $observationid],
         ];
 
         return $table->out($table->pagesize, true);

--- a/classes/table/notifications/notifications_table.php
+++ b/classes/table/notifications/notifications_table.php
@@ -50,13 +50,13 @@ class notifications_table extends \table_sql implements \renderable {
         $columns = [
             'id',
             'time_before',
-            'actions'
+            'actions',
         ];
 
         $headers = [
             get_string('id', 'observation'),
             get_string('notifyon', 'observation'),
-            get_string('actions', 'observation')
+            get_string('actions', 'observation'),
         ];
 
         $this->define_columns($columns);

--- a/classes/table/timeslots/timeslots_display.php
+++ b/classes/table/timeslots/timeslots_display.php
@@ -78,7 +78,7 @@ class timeslots_display {
         'from' => '{observation_timeslots} ot
                     LEFT JOIN {user} u ON ot.observer_id = u.id
                     LEFT JOIN {user} o on ot.observee_id = o.id',
-        'where' => 'obs_id = :obsid'
+        'where' => 'obs_id = :obsid',
     ];
 
     /**

--- a/classes/table/viewpoints/viewpoints_display.php
+++ b/classes/table/viewpoints/viewpoints_display.php
@@ -48,7 +48,7 @@ class viewpoints_display {
             'fields' => 'op.*, ortm.lang_string',
             'from' => '{observation_points} op LEFT JOIN {observation_res_type_map} ortm ON op.res_type = ortm.res_type',
             'where' => 'obs_id = :obsid',
-            'params' => ['obsid' => $observationid]
+            'params' => ['obsid' => $observationid],
         ];
         $table->sql = $sql;
         return $table->out($table->pagesize, true);

--- a/classes/table/viewpoints/viewpoints_table.php
+++ b/classes/table/viewpoints/viewpoints_table.php
@@ -42,10 +42,10 @@ class viewpoints_table extends \table_sql implements \renderable {
      * Constructs the table and defines how the data from the SQL query is displayed
      * @param string $uniqueid ID that uniquely identifies this element on the HTML page
      * @param \moodle_url $callbackurl URL used for callback for action buttons in the table
-     * @param int $displaymode display mode for table
+     * @param int|null $displaymode display mode for table
      * @param int $perpage number of entries per page for the table
      */
-    public function __construct(string $uniqueid, \moodle_url $callbackurl, int $displaymode = null, int $perpage = 50) {
+    public function __construct(string $uniqueid, \moodle_url $callbackurl, ?int $displaymode = null, int $perpage = 50) {
         parent::__construct($uniqueid);
 
         $this->define_columns([

--- a/classes/table/viewsessions/viewsessions_display.php
+++ b/classes/table/viewsessions/viewsessions_display.php
@@ -58,7 +58,7 @@ class viewsessions_display {
                   ) as observees
             ON os.observee_id = observees.observee_id',
             'where' => 'obs_id = :obsid',
-            'params' => ['obsid' => $observationid]
+            'params' => ['obsid' => $observationid],
         ];
         $table->sql = $sql;
         return $table->out($table->pagesize, true);

--- a/classes/table/viewsessions/viewsessions_table.php
+++ b/classes/table/viewsessions/viewsessions_table.php
@@ -54,7 +54,7 @@ class viewsessions_table extends \table_sql implements \renderable {
             'state',
             'start_time',
             'finish_time',
-            'action'
+            'action',
         ]);
 
         $this->define_headers([

--- a/classes/timeslot_manager.php
+++ b/classes/timeslot_manager.php
@@ -280,12 +280,12 @@ class timeslot_manager {
         // Multiplier on form is set via a select which passes value as string, so cast to int.
         $intmultiplier = (int) $formdata->interval_multiplier;
 
-        $dbdata = array(
+        $dbdata = [
             "obs_id" => $formdata->id,
             "start_time" => $formdata->start_time,
             "duration" => $formdata->duration,
-            "observer_id" => $formdata->observer_id
-        );
+            "observer_id" => $formdata->observer_id,
+        ];
 
         $intervalslots = self::generate_interval_timeslots($dbdata, $intamount, $intmultiplier, $intend);
 
@@ -345,7 +345,7 @@ class timeslot_manager {
             "obs_id" => $formdata->id,
             "start_time" => $formdata->start_time,
             "duration" => $formdata->duration,
-            "observer_id" => $formdata->observer_id
+            "observer_id" => $formdata->observer_id,
         ];
     }
 
@@ -395,14 +395,15 @@ class timeslot_manager {
         $dbdata = [
             'id' => $slotid,
             'observee_id' => $userid,
-            'obs_id' => $observationid
+            'obs_id' => $observationid,
         ];
 
         self::modify_time_slot($dbdata);
         self::send_signup_confirmation_message($observationid, $slotid, $userid);
     }
 
-    /** Determines if a user can unenrol from a timeslot as an observee
+    /**
+     * Determines if a user can unenrol from a timeslot as an observee
      * @param int $observationid ID of the observation
      * @param int $slotid ID of the timeslot
      * @param int $userid ID of user to remove
@@ -454,7 +455,7 @@ class timeslot_manager {
             'id' => $slotid,
             'observee_id' => null,
             'obs_id' => $observationid,
-            'observee_event_id' => null
+            'observee_event_id' => null,
         ];
 
         // Send cancellation message.
@@ -565,7 +566,7 @@ class timeslot_manager {
             "timeslot" => $slotdata,
             "observation" => $observation,
             "current_time_formatted" => userdate(time()),
-            "start_time_formatted" => userdate($slotdata->start_time)
+            "start_time_formatted" => userdate($slotdata->start_time),
         ];
 
         return $OUTPUT->render_from_template($template, $data);
@@ -602,7 +603,7 @@ class timeslot_manager {
 
         $DB->insert_record('observation_notifications', [
             'timeslot_id' => $slotid,
-            'time_before' => $interval * $multiplier
+            'time_before' => $interval * $multiplier,
         ]);
     }
 

--- a/db/access.php
+++ b/db/access.php
@@ -25,70 +25,70 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$capabilities = array(
-    'mod/observation:view' => array(
+$capabilities = [
+    'mod/observation:view' => [
         'captype' => 'read',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
             'student' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
-        )
-    ),
-    'mod/observation:addinstance' => array(
+        ],
+    ],
+    'mod/observation:addinstance' => [
         'riskbitmask' => RISK_XSS,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
-        )
-    ),
-    'mod/observation:editobservationpoints' => array(
+        ],
+    ],
+    'mod/observation:editobservationpoints' => [
         'riskbitmask' => RISK_XSS,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
-        )
-    ),
-    'mod/observation:edittimeslots' => array(
+        ],
+    ],
+    'mod/observation:edittimeslots' => [
         'riskbitmask' => RISK_XSS,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
-        )
-    ),
-    'mod/observation:performobservation' => array(
+        ],
+    ],
+    'mod/observation:performobservation' => [
         'riskbitmask' => RISK_PERSONAL,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'editingteacher' => CAP_ALLOW,
             'teacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
-        )
-    ),
-    'mod/observation:assignstudents' => array(
+        ],
+    ],
+    'mod/observation:assignstudents' => [
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
-        )
-    ),
-    'mod/observation:viewfiles' => array(
+        ],
+    ],
+    'mod/observation:viewfiles' => [
         'riskbitmask' => RISK_PERSONAL,
         'captype' => 'read',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'editingteacher' => CAP_ALLOW,
             'teacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
-        )
-    )
-);
+        ],
+    ],
+];

--- a/db/install.php
+++ b/db/install.php
@@ -35,7 +35,7 @@ function xmldb_observation_install() {
     $mappings = [
         ['res_type' => 0, 'lang_string' => 'textinputtype'],
         ['res_type' => 1, 'lang_string' => 'passfailtype'],
-        ['res_type' => 2, 'lang_string' => 'evidencetype']
+        ['res_type' => 2, 'lang_string' => 'evidencetype'],
     ];
     $DB->insert_records($tablename, $mappings);
 }

--- a/db/messages.php
+++ b/db/messages.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$messageproviders = array(
+$messageproviders = [
     // Confirm timeslot signup.
     'confirmsignup' => [],
 
@@ -33,5 +33,5 @@ $messageproviders = array(
     'signupreminder' => [],
 
     // Cancellation alert.
-    'cancellationalert' => []
-);
+    'cancellationalert' => [],
+];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -95,7 +95,7 @@ function xmldb_observation_upgrade($oldversion) {
                 // Move to the new file area and record using response ID as the 'item' id.
                 $changes = [
                     'filearea' => 'response',
-                    'itemid' => $newfileitemid
+                    'itemid' => $newfileitemid,
                 ];
                 $migratedfile = $storage->create_file_from_storedfile($changes, $file->id);
 

--- a/lib.php
+++ b/lib.php
@@ -54,7 +54,7 @@ function observation_get_course_content_items(\core_course\local\entity\content_
  * @return int new observation instance id
  */
 function observation_add_instance($data): int {
-    return \mod_observation\observation_manager::modify_instance(array(
+    return \mod_observation\observation_manager::modify_instance([
         "course" => (int)$data->course,
         "name" => $data->name,
         "intro" => "",
@@ -63,8 +63,8 @@ function observation_add_instance($data): int {
         "observer_ins_f" => $data->observerins_editor['format'],
         "observee_ins" => $data->observeeins_editor['text'],
         "observee_ins_f" => $data->observeeins_editor['format'],
-        "students_self_unregister" => (int) $data->students_self_unregister
-    ));
+        "students_self_unregister" => (int) $data->students_self_unregister,
+    ]);
 }
 
 /**
@@ -76,7 +76,7 @@ function observation_add_instance($data): int {
  * @return bool true on success, false or a string error message on failure.
  */
 function observation_update_instance($data): bool {
-    $success = \mod_observation\observation_manager::modify_instance(array(
+    $success = \mod_observation\observation_manager::modify_instance([
         "id" => $data->instance,
         "name" => $data->name,
         "timemodified" => time(),
@@ -84,8 +84,8 @@ function observation_update_instance($data): bool {
         "observer_ins_f" => $data->observerins_editor['format'],
         "observee_ins" => $data->observeeins_editor['text'],
         "observee_ins_f" => $data->observeeins_editor['format'],
-        "students_self_unregister" => (int) $data->students_self_unregister
-    ));
+        "students_self_unregister" => (int) $data->students_self_unregister,
+    ]);
 
     if ($success === true) {
         // Update all the calendar events to get the new data.
@@ -172,7 +172,7 @@ function mod_observation_core_calendar_is_event_visible(calendar_event $event) {
         "observerevent" => $event->id,
         "observeeevent" => $event->id,
         "observer" => $USER->id,
-        "observee" => $USER->id
+        "observee" => $USER->id,
     ];
 
     $matchingevent = $DB->get_records_sql($sql, $params);
@@ -189,7 +189,7 @@ function mod_observation_core_calendar_is_event_visible(calendar_event $event) {
  * @param bool $forcedownload bool if download should be forced
  * @param array $options an array of options
  */
-function observation_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options=array()) {
+function observation_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options=[]) {
     // Ensure logged in to course.
     require_course_login($course->id);
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -41,7 +41,7 @@ class mod_observation_mod_form extends moodleform_mod {
 
         // General.
         $mform->addElement('header', 'general', get_string('general', 'observation'));
-        $mform->addElement('text', 'name', get_string('name'), array('size' => '64'));
+        $mform->addElement('text', 'name', get_string('name'), ['size' => '64']);
         $mform->setType('name', PARAM_TEXT);
 
         // Activity Instructions Elements.
@@ -84,16 +84,16 @@ class mod_observation_mod_form extends moodleform_mod {
         }
 
         // Editing, find the defaults and update the form values.
-        $obsdata = (object) $DB->get_record('observation', array('id' => $obsid));
+        $obsdata = (object) $DB->get_record('observation', ['id' => $obsid]);
 
         $defaultvalues['observerins_editor'] = (object) [
             'text' => $obsdata->observer_ins,
-            'format' => $obsdata->observer_ins_f
+            'format' => $obsdata->observer_ins_f,
         ];
 
         $defaultvalues['observeeins_editor'] = (object) [
             'text' => $obsdata->observee_ins,
-            'format' => $obsdata->observee_ins_f
+            'format' => $obsdata->observee_ins_f,
         ];
 
         return;

--- a/observee.php
+++ b/observee.php
@@ -32,7 +32,7 @@ list($observation, $course, $cm) = \mod_observation\observation_manager::get_obs
 require_login($course, true, $cm);
 
 // Render page.
-$pageurl = new moodle_url('/mod/observation/observee.php', array('id' => $id));
+$pageurl = new moodle_url('/mod/observation/observee.php', ['id' => $id]);
 $PAGE->set_url($pageurl);
 $PAGE->set_title($course->shortname.': '.$observation->name);
 $PAGE->set_heading($course->fullname);
@@ -41,7 +41,7 @@ echo $OUTPUT->heading($observation->name, 2);
 
 echo $OUTPUT->box_start();
 echo $OUTPUT->single_button(
-    new moodle_url('/mod/observation/timeslotjoining.php', array('id' => $observation->id)),
+    new moodle_url('/mod/observation/timeslotjoining.php', ['id' => $observation->id]),
     get_string('selectingslot', 'observation')
 );
 echo $OUTPUT->box_end();

--- a/observer.php
+++ b/observer.php
@@ -33,7 +33,7 @@ require_login($course, true, $cm);
 require_capability('mod/observation:performobservation', $PAGE->context);
 
 // Render page.
-$pageurl = new moodle_url('/mod/observation/observer.php', array('id' => $id));
+$pageurl = new moodle_url('/mod/observation/observer.php', ['id' => $id]);
 $PAGE->set_url($pageurl);
 $PAGE->set_title($course->shortname.': '.$observation->name);
 $PAGE->set_heading($course->fullname);
@@ -47,7 +47,7 @@ echo $OUTPUT->heading(get_string('actions', 'observation'), 3);
 // Edit observation point link button.
 if (has_capability('mod/observation:editobservationpoints', $PAGE->context)) {
     echo $OUTPUT->single_button(
-        new moodle_url('/mod/observation/viewpoints.php', array('id' => $observation->id)),
+        new moodle_url('/mod/observation/viewpoints.php', ['id' => $observation->id]),
         get_string('editobservationpoints', 'observation'),
         'get'
     );
@@ -56,7 +56,7 @@ if (has_capability('mod/observation:editobservationpoints', $PAGE->context)) {
 // Edit timeslots link button.
 if (has_capability('mod/observation:edittimeslots', $PAGE->context)) {
     echo $OUTPUT->single_button(
-        new moodle_url('/mod/observation/timeslots.php', array('id' => $observation->id)),
+        new moodle_url('/mod/observation/timeslots.php', ['id' => $observation->id]),
         get_string('edittimeslotss', 'observation'),
         'get'
     );

--- a/pointeditor.php
+++ b/pointeditor.php
@@ -35,7 +35,7 @@ if ($mode !== 'new' && $mode !== 'edit') {
         'invalidqueryparam',
         'error',
         null,
-        $a = array('expected' => 'mode to be \'new\' or \'edit\'', 'actual' => $mode));
+        $a = ['expected' => 'mode to be \'new\' or \'edit\'', 'actual' => $mode]);
 }
 
 // Ensure pointID is given if mode is 'edit'.
@@ -50,11 +50,11 @@ require_login($course, true, $cm);
 require_capability('mod/observation:editobservationpoints', $PAGE->context);
 
 // Prefill hidden data in form regardless of mode.
-$formprefill = array(
+$formprefill = [
     'id' => $id,
     'mode' => $mode,
     'pointid' => $pointid,
-);
+];
 
 // If editing, add prefill data from DB.
 if ($mode === "edit") {
@@ -73,7 +73,7 @@ $pointeditorform = new \mod_observation\form\pointeditor(null, $formprefill);
 
 // Form submitted, save/edit the data.
 if ($fromform = $pointeditorform->get_data()) {
-    $dbdata = array(
+    $dbdata = [
         "obs_id" => $fromform->id,
         "title" => $fromform->title,
         "ins" => $fromform->ins['text'],
@@ -81,7 +81,7 @@ if ($fromform = $pointeditorform->get_data()) {
         "max_grade" => $fromform->maxgrade,
         "res_type" => $fromform->res_type,
         "file_size" => (int)$fromform->res_type === 2 ? $fromform->file_size : null,
-    );
+    ];
 
     if ($fromform->mode === "new") {
         // Creating new.
@@ -93,12 +93,12 @@ if ($fromform = $pointeditorform->get_data()) {
     }
 
     // Redirect back to point viewer.
-    redirect(new moodle_url('viewpoints.php', array('id' => $id)));
+    redirect(new moodle_url('viewpoints.php', ['id' => $id]));
     die;
 }
 
 // Form not submitted, render form.
-$PAGE->set_url(new moodle_url('/mod/observation/pointeditor.php', array('mode' => $mode, 'id' => $id)));
+$PAGE->set_url(new moodle_url('/mod/observation/pointeditor.php', ['mode' => $mode, 'id' => $id]));
 $PAGE->set_title(get_string('creatingobservationpoint', 'observation'));
 $PAGE->set_heading($course->fullname);
 echo $OUTPUT->header();

--- a/pointeditor.php
+++ b/pointeditor.php
@@ -65,7 +65,7 @@ if ($mode === "edit") {
     $formprefill['maxgrade'] = $pointdata->max_grade;
     $formprefill['title'] = $pointdata->title;
     $formprefill['ins']['text'] = $pointdata->ins;
-    $formprefill['ins']['format'] = $pointdata->ins_f;
+    $formprefill['ins']['format'] = (int) $pointdata->ins_f;
 }
 
 // Load form.

--- a/session.php
+++ b/session.php
@@ -160,25 +160,25 @@ if ($confirmcancel === 1) {
 // If confirmation rejected proceed back to session.php.
 if ($confirmcancel === 0) {
     // Return to session page.
-    redirect(new moodle_url('/mod/observation/session.php', array('sessionid' => $sessionid)));
+    redirect(new moodle_url('/mod/observation/session.php', ['sessionid' => $sessionid]));
 }
 
 // If confirmation approved proceed to submit session.
 if ($confirmsubmit === 1) {
     // Redirect to final session page (summary, add final comments, etc.).
-    redirect(new moodle_url('/mod/observation/sessionsummary.php', array('sessionid' => $sessionid)));
+    redirect(new moodle_url('/mod/observation/sessionsummary.php', ['sessionid' => $sessionid]));
 }
 
 // If confirmation rejected proceed back to session.php.
 if ($confirmsubmit === 0) {
     // Return to session page.
-    redirect(new moodle_url('/mod/observation/session.php', array('sessionid' => $sessionid)));
+    redirect(new moodle_url('/mod/observation/session.php', ['sessionid' => $sessionid]));
 }
 
 // Render page.
-$pageurl = new moodle_url('/mod/observation/session.php', array(
-    'sessionid' => $sessionid, 'pointid' => $pointid
-));
+$pageurl = new moodle_url('/mod/observation/session.php', [
+    'sessionid' => $sessionid, 'pointid' => $pointid,
+]);
 $pageurl->out(false);
 $PAGE->set_url($pageurl);
 $PAGE->set_title($course->shortname . ': ' . $observation->name);

--- a/sessionsummary.php
+++ b/sessionsummary.php
@@ -49,7 +49,7 @@ $gradeformatted = $grade['total'].'/'.$grade['max'];
 $formprefill = [
     'gradecalculated' => $gradeformatted,
     'sessionid' => $sessionid,
-    'extracomment' => $sessioninfo['ex_comment']
+    'extracomment' => $sessioninfo['ex_comment'],
 ];
 
 $submitform = new \mod_observation\form\sessionsubmit(null, $formprefill, 'post', '', null, !$isviewonly);

--- a/sessionview.php
+++ b/sessionview.php
@@ -60,7 +60,7 @@ $upcomingprefill = [
     'id' => $id,
     'interval_amount' => $interval,
     'interval_multiplier' => $intervalmultiplier,
-    'filter_enabled' => $filterenabled
+    'filter_enabled' => $filterenabled,
 ];
 
 $upcomingfilterform = new \mod_observation\form\upcomingfilter(null, $upcomingprefill);
@@ -79,7 +79,7 @@ if ($fromform = $upcomingfilterform->get_data()) {
 
 $startsessionformprefill = [
     'id' => $id,
-    'observerid' => $USER->id
+    'observerid' => $USER->id,
 ];
 $startsessionform = new \mod_observation\form\startsession(null, $startsessionformprefill);
 

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -78,21 +78,21 @@ class mod_observation_generator extends testing_module_generator {
      * @return stdClass
      * @throws coding_exception
      */
-    public function create_instance($record = null, array $options = null) {
+    public function create_instance($record = null, ?array $options = null) {
         $record = (object)(array)$record;
 
         // Default editor values.
-        $defaulteditorvalues = array(
+        $defaulteditorvalues = [
             'text' => null,
             'format' => null,
-        );
+        ];
 
         // Default observation activity settings.
-        $defaultobservationsettings = array(
+        $defaultobservationsettings = [
             'observerins_editor' => $defaulteditorvalues,
             'observeeins_editor' => $defaulteditorvalues,
             'students_self_unregister' => 0,
-        );
+        ];
 
         // Set defaults if not already set.
         foreach ($defaultobservationsettings as $name => $value) {

--- a/tests/observation_point_test.php
+++ b/tests/observation_point_test.php
@@ -89,7 +89,7 @@ class observation_point_test extends advanced_testcase {
     /**
      * Tests CRUD operations for observation point with expected data.
      */
-    public function test_crud_expected () {
+    public function test_crud_expected() {
         global $DB;
 
         $data = self::VALID_DATA;
@@ -155,7 +155,7 @@ class observation_point_test extends advanced_testcase {
     /**
      * Tests the ordering logic for a single observation point.
      */
-    public function test_ordering_single () {
+    public function test_ordering_single() {
         // Generate a single valid point.
         $returnedpoint = self::create_valid_point($this->instance->id);
 

--- a/tests/observation_session_test.php
+++ b/tests/observation_session_test.php
@@ -47,7 +47,7 @@ class observation_session_test extends advanced_testcase {
     private const VALID_RESPONSE = [
         'grade_given' => 3,
         'response' => 'test response',
-        'ex_comment' => 'extra comment'
+        'ex_comment' => 'extra comment',
     ];
 
 

--- a/tests/provider_test.php
+++ b/tests/provider_test.php
@@ -83,7 +83,7 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             'duration' => 5,
             'obs_id' => $this->instance->id,
             'observer_id' => $this->observer->id,
-            'observee_id' => $this->observee->id
+            'observee_id' => $this->observee->id,
         ];
 
         \mod_observation\timeslot_manager::modify_time_slot($tsdata);
@@ -112,7 +112,7 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             'duration' => 5,
             'obs_id' => $this->instance->id,
             'observer_id' => $this->observer->id,
-            'observee_id' => $this->observee->id
+            'observee_id' => $this->observee->id,
         ];
 
         \mod_observation\timeslot_manager::modify_time_slot($tsdata);
@@ -144,7 +144,7 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             'duration' => 5,
             'obs_id' => $this->instance->id,
             'observer_id' => $this->observer->id,
-            'observee_id' => $this->observee->id
+            'observee_id' => $this->observee->id,
         ];
 
         \mod_observation\timeslot_manager::modify_time_slot($tsdata);
@@ -160,14 +160,14 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             'obs_id' => $this->instance->id,
             'title' => 'point1',
             'max_grade' => 5,
-            'res_type' => \mod_observation\observation_manager::INPUT_TEXT
+            'res_type' => \mod_observation\observation_manager::INPUT_TEXT,
         ], true);
 
         // Make a response to the session.
         \mod_observation\observation_manager::submit_point_response($sessid, $obpoint, (object)[
             'grade_given' => 5,
             'response' => 'response text',
-            'ex_comment' => 'extra comment'
+            'ex_comment' => 'extra comment',
         ]);
 
         // Ensure they have been created properly.
@@ -206,7 +206,7 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             'duration' => 5,
             'obs_id' => $this->instance->id,
             'observer_id' => $this->observer->id,
-            'observee_id' => $this->observee->id
+            'observee_id' => $this->observee->id,
         ];
 
         \mod_observation\timeslot_manager::modify_time_slot($tsdata);
@@ -219,14 +219,14 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             'obs_id' => $this->instance->id,
             'title' => 'point1',
             'max_grade' => 5,
-            'res_type' => \mod_observation\observation_manager::INPUT_TEXT
+            'res_type' => \mod_observation\observation_manager::INPUT_TEXT,
         ], true);
 
         // Make a response to the session.
         \mod_observation\observation_manager::submit_point_response($sessid, $obpoint, (object)[
             'grade_given' => 5,
             'response' => 'response text',
-            'ex_comment' => 'extra comment'
+            'ex_comment' => 'extra comment',
         ]);
 
         // Ensure they have been created properly.
@@ -265,7 +265,7 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             'obs_id' => $this->instance->id,
             'title' => 'point1',
             'max_grade' => 5,
-            'res_type' => \mod_observation\observation_manager::INPUT_TEXT
+            'res_type' => \mod_observation\observation_manager::INPUT_TEXT,
         ], true);
 
         // Create additional user.
@@ -282,7 +282,7 @@ class provider_test extends \core_privacy\tests\provider_testcase {
                 'duration' => 5,
                 'obs_id' => $this->instance->id,
                 'observer_id' => $this->observer->id,
-                'observee_id' => $userid
+                'observee_id' => $userid,
             ];
 
             \mod_observation\timeslot_manager::modify_time_slot($tsdata);
@@ -294,7 +294,7 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             \mod_observation\observation_manager::submit_point_response($sessid, $obpoint, (object)[
                 'grade_given' => 5,
                 'response' => 'response text',
-                'ex_comment' => 'extra comment'
+                'ex_comment' => 'extra comment',
             ]);
         }
 
@@ -328,7 +328,7 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             'duration' => 5,
             'obs_id' => $this->instance->id,
             'observer_id' => $this->observer->id,
-            'observee_id' => $this->observee->id
+            'observee_id' => $this->observee->id,
         ];
 
         \mod_observation\timeslot_manager::modify_time_slot($tsdata);
@@ -341,14 +341,14 @@ class provider_test extends \core_privacy\tests\provider_testcase {
             'obs_id' => $this->instance->id,
             'title' => 'point1',
             'max_grade' => 5,
-            'res_type' => \mod_observation\observation_manager::INPUT_TEXT
+            'res_type' => \mod_observation\observation_manager::INPUT_TEXT,
         ], true);
 
         // Make a response to the session to the observation point.
         \mod_observation\observation_manager::submit_point_response($sessid, $obpoint, (object)[
             'grade_given' => 5,
             'response' => 'response text',
-            'ex_comment' => 'extra comment'
+            'ex_comment' => 'extra comment',
         ]);
 
         // Export the user data for this user.

--- a/tests/timeslot_joining_test.php
+++ b/tests/timeslot_joining_test.php
@@ -87,7 +87,7 @@ class timeslot_joining_test extends advanced_testcase {
     /**
      * Tests basic joining functions.
      */
-    public function test_joining_function () {
+    public function test_joining_function() {
         $obid = $this->instance->id;
 
         // Observee 1 joins timeslot 1, Observee 2 joins timeslot 2.
@@ -104,7 +104,7 @@ class timeslot_joining_test extends advanced_testcase {
     /**
      * Tests if students are not allowed to join multiple timeslots.
      */
-    public function test_double_joining () {
+    public function test_double_joining() {
         $obid = $this->instance->id;
 
         // Observee 1 tries to join both timeslots 1 and 2 (not allowed).
@@ -117,7 +117,7 @@ class timeslot_joining_test extends advanced_testcase {
     /**
      * Tests if two students are not allowed to join same timeslot.
      */
-    public function test_join_filled () {
+    public function test_join_filled() {
         $obid = $this->instance->id;
 
         // Observee 1 joins timeslot 1.

--- a/tests/timeslot_notification_test.php
+++ b/tests/timeslot_notification_test.php
@@ -170,11 +170,11 @@ class timeslot_notification_test extends advanced_testcase {
     public function test_invalid_interval() {
         $invalidvars = [
             '',
-            array(),
+            [],
             true,
             -10,
             new \StdClass,
-            0.5
+            0.5,
         ];
 
         foreach ($invalidvars as $var) {
@@ -198,11 +198,11 @@ class timeslot_notification_test extends advanced_testcase {
     public function test_invalid_multiplier() {
         $invalidvars = [
             '',
-            array(),
+            [],
             true,
             -10,
             new \StdClass,
-            0.5
+            0.5,
         ];
 
         foreach ($invalidvars as $var) {

--- a/tests/timeslots_test.php
+++ b/tests/timeslots_test.php
@@ -89,7 +89,7 @@ class timeslots_test extends advanced_testcase {
     /**
      * Tests basic CRUD actions for timeslots using valid data.
      */
-    public function test_valid_crud () {
+    public function test_valid_crud() {
         // Test create.
         $obid = $this->instance->id;
         $data = $this->create_valid_timeslot();

--- a/timesloteditor.php
+++ b/timesloteditor.php
@@ -37,7 +37,7 @@ if (!in_array($mode, $validmodes)) {
         'invalidqueryparam',
         'error',
         null,
-        $a = array('expected' => 'mode to be \'new\' or \'edit\'', 'actual' => $mode));
+        $a = ['expected' => 'mode to be \'new\' or \'edit\'', 'actual' => $mode]);
 }
 
 // Ensure slotID is given if mode is 'edit'.
@@ -52,11 +52,11 @@ require_login($course, true, $cm);
 require_capability('mod/observation:editobservationpoints', $PAGE->context);
 
 // Prefill hidden data in form regardless of mode.
-$formprefill = array(
+$formprefill = [
     'id' => $id,
     'mode' => $mode,
     'slotid' => $slotid,
-);
+];
 
 // If editing, add prefill data from DB.
 if ($mode === "edit") {
@@ -100,13 +100,13 @@ if ($fromform = $sloteditorform->get_data()) {
         }
 
         // Redirect back to slot viewer.
-        redirect(new moodle_url('timeslots.php', array('id' => $id)));
+        redirect(new moodle_url('timeslots.php', ['id' => $id]));
         die;
     }
 }
 
 // Form not submitted, render form.
-$PAGE->set_url(new moodle_url('/mod/observation/timesloteditor.php', array('mode' => $mode, 'id' => $id)));
+$PAGE->set_url(new moodle_url('/mod/observation/timesloteditor.php', ['mode' => $mode, 'id' => $id]));
 $PAGE->set_title(get_string('creatingtimeslot', 'observation'));
 $PAGE->set_heading($course->fullname);
 echo $OUTPUT->header();

--- a/timeslotjoining.php
+++ b/timeslotjoining.php
@@ -37,7 +37,7 @@ list($observation, $course, $cm) = \mod_observation\observation_manager::get_obs
 // Check permissions.
 require_login($course, true, $cm);
 
-$pageurl = new moodle_url('/mod/observation/timeslotjoining.php', array('id' => $id));
+$pageurl = new moodle_url('/mod/observation/timeslotjoining.php', ['id' => $id]);
 
 if ($action !== null) {
     require_sesskey();
@@ -72,7 +72,7 @@ if ($action !== null) {
 }
 
 // Render page.
-$pageurl = new moodle_url('/mod/observation/timeslotjoining.php', array('id' => $id));
+$pageurl = new moodle_url('/mod/observation/timeslotjoining.php', ['id' => $id]);
 $PAGE->set_url($pageurl);
 $PAGE->set_title($course->shortname.': '.$observation->name);
 $PAGE->set_heading($course->fullname);

--- a/timeslotnotifications.php
+++ b/timeslotnotifications.php
@@ -55,14 +55,14 @@ $timeslot = \mod_observation\timeslot_manager::get_registered_timeslot($observat
 // Load forms.
 $prefill = [
     'id' => $observation->id,
-    'slotid' => $timeslot->id
+    'slotid' => $timeslot->id,
 ];
 $notificationeditor = new \mod_observation\form\notificationeditor(null, $prefill);
 
 if ($fromform = $notificationeditor->get_data()) {
     $data = (object) [
         'interval_amount' => (int)$fromform->interval_amount,
-        'interval_multiplier' => (int)$fromform->interval_multiplier
+        'interval_multiplier' => (int)$fromform->interval_multiplier,
     ];
 
     \mod_observation\timeslot_manager::create_notification($fromform->id, $fromform->slotid, $USER->id, $data);

--- a/timeslots.php
+++ b/timeslots.php
@@ -36,7 +36,7 @@ list($observation, $course, $cm) = \mod_observation\observation_manager::get_obs
 require_login($course, true, $cm);
 require_capability('mod/observation:editobservationpoints', $PAGE->context);
 
-$pageurl = new moodle_url('/mod/observation/timeslots.php', array('id' => $id));
+$pageurl = new moodle_url('/mod/observation/timeslots.php', ['id' => $id]);
 
 // Check if action and slotid are present.
 if (!empty($action) && !empty($slotid)) {
@@ -70,7 +70,7 @@ if (!empty($action) && !empty($slotid)) {
 }
 
 // Render page.
-$pageurl = new moodle_url('/mod/observation/timeslots.php', array('id' => $id));
+$pageurl = new moodle_url('/mod/observation/timeslots.php', ['id' => $id]);
 $PAGE->set_url($pageurl);
 $PAGE->set_title($course->shortname.': '.$observation->name);
 $PAGE->set_heading($course->fullname);
@@ -82,14 +82,14 @@ echo $OUTPUT->container_start('mb-3 p-3 border border-secondary');
 
 // Create new time slot.
 echo $OUTPUT->single_button(
-    new moodle_url('/mod/observation/timesloteditor.php', array('mode' => 'new', 'id' => $observation->id)),
+    new moodle_url('/mod/observation/timesloteditor.php', ['mode' => 'new', 'id' => $observation->id]),
     get_string('createnew', 'observation'),
     'get'
 );
 
 // Randomly assign students to timeslots.
 echo $OUTPUT->single_button(
-    new moodle_url('/mod/observation/assignstudents.php', array('mode' => 'randomassign', 'id' => $observation->id)),
+    new moodle_url('/mod/observation/assignstudents.php', ['mode' => 'randomassign', 'id' => $observation->id]),
     get_string('randomlyassign', 'observation'),
     'get'
 );

--- a/version.php
+++ b/version.php
@@ -30,4 +30,4 @@ $plugin->release   = 2024052801;
 $plugin->requires  = 2022041900;
 $plugin->component = 'mod_observation';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->supported = [40, 41];
+$plugin->supported = [400, 401];

--- a/view.php
+++ b/view.php
@@ -47,11 +47,11 @@ require_login($course, true, $cm);
 
 // If user can perform observations, redirect to the 'observer' view.
 if (has_capability('mod/observation:performobservation', $PAGE->context)) {
-    $observerurl = new moodle_url('/mod/observation/observer.php', array('id' => $observation->id));
+    $observerurl = new moodle_url('/mod/observation/observer.php', ['id' => $observation->id]);
     redirect($observerurl);
     die;
 }
 
 // Else, redirect user to 'observee' view (default).
-$observeeurl = new moodle_url('/mod/observation/observee.php', array('id' => $observation->id));
+$observeeurl = new moodle_url('/mod/observation/observee.php', ['id' => $observation->id]);
 redirect($observeeurl);

--- a/viewpoints.php
+++ b/viewpoints.php
@@ -35,7 +35,7 @@ list($observation, $course, $cm) = \mod_observation\observation_manager::get_obs
 require_login($course, true, $cm);
 require_capability('mod/observation:editobservationpoints', $PAGE->context);
 
-$pageurl = new moodle_url('/mod/observation/viewpoints.php', array('id' => $id));
+$pageurl = new moodle_url('/mod/observation/viewpoints.php', ['id' => $id]);
 
 // Check if action and pointid are present.
 if (!empty($action) && !empty($pointid)) {
@@ -73,7 +73,7 @@ if (!empty($action) && !empty($pointid)) {
 }
 
 // Render page.
-$pageurl = new moodle_url('/mod/observation/viewpoints.php', array('id' => $id));
+$pageurl = new moodle_url('/mod/observation/viewpoints.php', ['id' => $id]);
 $PAGE->set_url($pageurl);
 $PAGE->set_title($course->shortname.': '.$observation->name);
 $PAGE->set_heading($course->fullname);
@@ -85,7 +85,7 @@ echo $OUTPUT->box_start();
 
 // Create new observation point.
 echo $OUTPUT->single_button(
-    new moodle_url('/mod/observation/pointeditor.php', array('mode' => 'new', 'id' => $observation->id)),
+    new moodle_url('/mod/observation/pointeditor.php', ['mode' => 'new', 'id' => $observation->id]),
     get_string('createnew', 'observation'),
     'get'
 );


### PR DESCRIPTION
Closes #140 

**Changes**
- According to https://docs.moodle.org/dev/lib/formslib.php_Form_Definition#editor editors must be PARAM_RAW not PARAM_TEXT (if PARAM_TEXT, html is stripped out which is what was happening before)
- Additionally, the editors needed the format passed in as a integer not a string.

Other misc updates:

- Fix `version.php` so the ci actually runs - wasn't actually running anything at all before :see_no_evil: 
- Fix up about a zillion codechecker and phpdoc issues

**Testing**
Tested this manually saving and loading observation point html, now correctly saves the html tags and displays it properly