### PR TITLE
[#143][#144] Change !is_null to isset

### DIFF
--- a/session.php
+++ b/session.php
@@ -114,7 +114,7 @@ if ($fromform = $markingform->get_data()) {
     }
 
     // If save and continue button pressed, find next observation point to redirect to.
-    if (!is_null($fromform->saveandnext)) {
+    if (isset($fromform->saveandnext)) {
         $allpointids = array_column($observationpoints, 'point_id');
         $index = array_search($pointid, $allpointids);
 
@@ -191,7 +191,7 @@ if ($markingform->no_submit_button_pressed()) {
     $fromform = $markingform->get_submitted_data();
 
     // Cancel / abandon observation button pressed.
-    if (!is_null($fromform->abandonbutton)) {
+    if (isset($fromform->abandonbutton)) {
         // If no confirmation yet, display confirmation dialog.
         if ($confirmcancel === null) {
             echo $OUTPUT->confirm(
@@ -203,7 +203,7 @@ if ($markingform->no_submit_button_pressed()) {
     }
 
     // Submit observation button pressed.
-    if (!is_null($fromform->submitobservation)) {
+    if (isset($fromform->submitobservation)) {
 
         // If no confirmation yet, display confirmation dialog.
         if ($confirmsubmit === null) {


### PR DESCRIPTION
This merge request fixes issues (https://github.com/catalyst/moodle-mod_observation/issues/143 & https://github.com/catalyst/moodle-mod_observation/issues/144) where accessing `$fromform->saveandnext`, `$fromform->abandonbutton`, `$fromform->submitobservation` could trigger an undefined property notice. Replaced `!is_null($var->property)` with `isset($var->property)`, which ensures the property is checked safely before access.


Testing - UI & Unit tests

```
root@37cef3b8c11c:/var/www/mdl45-unicat-wr# vendor/bin/phpunit --testsuite mod_observation_testsuite
Moodle 4.5.10+ (Build: 20260327), 57b76e8ee0a041e563e9f42185d77a0897f1ac2e
Php: 8.3.26, pgsql: 17.9 (Debian 17.9-1.pgdg13+1), OS: Linux 6.17.0-1012-oem x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

..........................................................        58 / 58 (100%)

Time: 00:13.491, Memory: 113.00 MB

OK (58 tests, 164 assertions)
```