### PR TITLE
[#146] Add observee visibility

### DIFF
--- a/classes/observation_manager.php
+++ b/classes/observation_manager.php
@@ -405,7 +405,7 @@ class observation_manager {
         $out .= $OUTPUT->heading(get_string('observee', 'observation') . ': ' . fullname($observee, $canviewfullnames), 5);
 
         // Build secondary details line - only include fields the admin has enabled and the
-        // current user is permitted to view.
+        // Current user is permitted to view.
         $observeedetails = [];
         if (in_array('email', $identityfields) && !empty($observee->email)) {
             $observeedetails[] = get_string('email') . ': ' .

--- a/classes/observation_manager.php
+++ b/classes/observation_manager.php
@@ -398,7 +398,7 @@ class observation_manager {
         // Determine which identity fields the current user (grader) is permitted to see.
         $identityfields = \core_user\fields::get_identity_fields($context, false);
 
-        // fullname() respects $CFG->fullnamedisplay / $CFG->alternativefullnameformat.
+        // Variable fullname() respects $CFG->fullnamedisplay / $CFG->alternativefullnameformat.
         $canviewfullnames = has_capability('moodle/site:viewfullnames', $context);
 
         $out = $OUTPUT->container_start('my-2');

--- a/classes/observation_manager.php
+++ b/classes/observation_manager.php
@@ -384,6 +384,44 @@ class observation_manager {
     }
 
     /**
+     * Renders a labelled info box showing the observee's details to the grader.
+     * @param int $observeeid ID of the observee being observed in this session
+     * @param context $context context to check permissions against for which fields to show
+     * @return string HTML string
+     */
+    public static function render_observee_details(int $observeeid, \context $context) {
+        global $OUTPUT;
+
+        // Display the learner (observee) being observed.
+        $observee = \core_user::get_user($observeeid, '*', MUST_EXIST);
+
+        // Determine which identity fields the current user (grader) is permitted to see.
+        $identityfields = \core_user\fields::get_identity_fields($context, false);
+
+        // fullname() respects $CFG->fullnamedisplay / $CFG->alternativefullnameformat.
+        $canviewfullnames = has_capability('moodle/site:viewfullnames', $context);
+
+        $out = $OUTPUT->container_start('my-2');
+        $out .= $OUTPUT->heading(get_string('observee', 'observation') . ': ' . fullname($observee, $canviewfullnames), 5);
+
+        // Build secondary details line - only include fields the admin has enabled and the
+        // current user is permitted to view.
+        $observeedetails = [];
+        if (in_array('email', $identityfields) && !empty($observee->email)) {
+            $observeedetails[] = get_string('email') . ': ' .
+                \html_writer::tag('a', $observee->email, ['href' => 'mailto:' . $observee->email]);
+        }
+        if (in_array('username', $identityfields) && !empty($observee->username)) {
+            $observeedetails[] = get_string('username') . ': ' . s($observee->username);
+        }
+        if (!empty($observeedetails)) {
+            $out .= \html_writer::tag('p', implode(' &nbsp;|&nbsp; ', $observeedetails), ['class' => 'text-muted mb-0']);
+        }
+        $out .= $OUTPUT->container_end();
+        return $out;
+    }
+
+    /**
      * Generates a HTML table that summarises the observation points and their responses
      * @param int $observationid ID of the observation instance
      * @param int $sessionid ID of the observation session

--- a/session.php
+++ b/session.php
@@ -187,6 +187,33 @@ $PAGE->set_heading($course->fullname);
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('markingobservation', 'observation'), 2);
 
+// Display the learner (observee) being observed.
+$observee = \core_user::get_user($sessiondata['observee'], '*', MUST_EXIST);
+
+// Determine which identity fields the current user (grader) is permitted to see.
+$identityfields = \core_user\fields::get_identity_fields($PAGE->context, false);
+
+// fullname() respects $CFG->fullnamedisplay / $CFG->alternativefullnameformat.
+$canviewfullnames = has_capability('moodle/site:viewfullnames', $PAGE->context);
+
+echo $OUTPUT->container_start('my-2');
+echo $OUTPUT->heading(get_string('observee', 'observation') . ': ' . fullname($observee, $canviewfullnames), 5);
+
+// Build secondary details line - only include fields the admin has enabled and the
+// current user is permitted to view.
+$observeedetails = [];
+if (in_array('email', $identityfields) && !empty($observee->email)) {
+    $observeedetails[] = get_string('email') . ': ' .
+        html_writer::tag('a', $observee->email, ['href' => 'mailto:' . $observee->email]);
+}
+if (in_array('username', $identityfields) && !empty($observee->username)) {
+    $observeedetails[] = get_string('username') . ': ' . s($observee->username);
+}
+if (!empty($observeedetails)) {
+    echo html_writer::tag('p', implode(' &nbsp;|&nbsp; ', $observeedetails), ['class' => 'text-muted mb-0']);
+}
+echo $OUTPUT->container_end();
+
 if ($markingform->no_submit_button_pressed()) {
     $fromform = $markingform->get_submitted_data();
 

--- a/session.php
+++ b/session.php
@@ -188,31 +188,7 @@ echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('markingobservation', 'observation'), 2);
 
 // Display the learner (observee) being observed.
-$observee = \core_user::get_user($sessiondata['observee'], '*', MUST_EXIST);
-
-// Determine which identity fields the current user (grader) is permitted to see.
-$identityfields = \core_user\fields::get_identity_fields($PAGE->context, false);
-
-// fullname() respects $CFG->fullnamedisplay / $CFG->alternativefullnameformat.
-$canviewfullnames = has_capability('moodle/site:viewfullnames', $PAGE->context);
-
-echo $OUTPUT->container_start('my-2');
-echo $OUTPUT->heading(get_string('observee', 'observation') . ': ' . fullname($observee, $canviewfullnames), 5);
-
-// Build secondary details line - only include fields the admin has enabled and the
-// current user is permitted to view.
-$observeedetails = [];
-if (in_array('email', $identityfields) && !empty($observee->email)) {
-    $observeedetails[] = get_string('email') . ': ' .
-        html_writer::tag('a', $observee->email, ['href' => 'mailto:' . $observee->email]);
-}
-if (in_array('username', $identityfields) && !empty($observee->username)) {
-    $observeedetails[] = get_string('username') . ': ' . s($observee->username);
-}
-if (!empty($observeedetails)) {
-    echo html_writer::tag('p', implode(' &nbsp;|&nbsp; ', $observeedetails), ['class' => 'text-muted mb-0']);
-}
-echo $OUTPUT->container_end();
+echo \mod_observation\observation_manager::render_observee_details($sessiondata['observee'], $PAGE->context);
 
 if ($markingform->no_submit_button_pressed()) {
     $fromform = $markingform->get_submitted_data();

--- a/sessionsummary.php
+++ b/sessionsummary.php
@@ -104,31 +104,7 @@ echo $OUTPUT->container_end();
 echo $OUTPUT->heading(get_string('sessionsummary', 'observation'), 2);
 
 // Display the learner (observee) being observed.
-$observee = \core_user::get_user($sessioninfo['observee'], '*', MUST_EXIST);
-
-// Determine which identity fields the current user (grader) is permitted to see.
-$identityfields = \core_user\fields::get_identity_fields($PAGE->context, false);
-
-// fullname() respects $CFG->fullnamedisplay / $CFG->alternativefullnameformat.
-$canviewfullnames = has_capability('moodle/site:viewfullnames', $PAGE->context);
-
-echo $OUTPUT->container_start('my-2');
-echo $OUTPUT->heading(get_string('observee', 'observation') . ': ' . fullname($observee, $canviewfullnames), 5);
-
-// Build secondary details line - only include fields the admin has enabled and the
-// current user is permitted to view.
-$observeedetails = [];
-if (in_array('email', $identityfields) && !empty($observee->email)) {
-    $observeedetails[] = get_string('email') . ': ' .
-        html_writer::tag('a', $observee->email, ['href' => 'mailto:' . $observee->email]);
-}
-if (in_array('username', $identityfields) && !empty($observee->username)) {
-    $observeedetails[] = get_string('username') . ': ' . s($observee->username);
-}
-if (!empty($observeedetails)) {
-    echo html_writer::tag('p', implode(' &nbsp;|&nbsp; ', $observeedetails), ['class' => 'text-muted mb-0']);
-}
-echo $OUTPUT->container_end();
+echo \mod_observation\observation_manager::render_observee_details($sessioninfo['observee'], $PAGE->context);
 
 // Summary of points and responses.
 echo \mod_observation\observation_manager::format_points_and_responses($obid, $sessionid);

--- a/sessionsummary.php
+++ b/sessionsummary.php
@@ -103,6 +103,33 @@ echo $OUTPUT->container_end();
 
 echo $OUTPUT->heading(get_string('sessionsummary', 'observation'), 2);
 
+// Display the learner (observee) being observed.
+$observee = \core_user::get_user($sessioninfo['observee'], '*', MUST_EXIST);
+
+// Determine which identity fields the current user (grader) is permitted to see.
+$identityfields = \core_user\fields::get_identity_fields($PAGE->context, false);
+
+// fullname() respects $CFG->fullnamedisplay / $CFG->alternativefullnameformat.
+$canviewfullnames = has_capability('moodle/site:viewfullnames', $PAGE->context);
+
+echo $OUTPUT->container_start('my-2');
+echo $OUTPUT->heading(get_string('observee', 'observation') . ': ' . fullname($observee, $canviewfullnames), 5);
+
+// Build secondary details line - only include fields the admin has enabled and the
+// current user is permitted to view.
+$observeedetails = [];
+if (in_array('email', $identityfields) && !empty($observee->email)) {
+    $observeedetails[] = get_string('email') . ': ' .
+        html_writer::tag('a', $observee->email, ['href' => 'mailto:' . $observee->email]);
+}
+if (in_array('username', $identityfields) && !empty($observee->username)) {
+    $observeedetails[] = get_string('username') . ': ' . s($observee->username);
+}
+if (!empty($observeedetails)) {
+    echo html_writer::tag('p', implode(' &nbsp;|&nbsp; ', $observeedetails), ['class' => 'text-muted mb-0']);
+}
+echo $OUTPUT->container_end();
+
 // Summary of points and responses.
 echo \mod_observation\observation_manager::format_points_and_responses($obid, $sessionid);
 


### PR DESCRIPTION
This merge request fixes issue (https://github.com/catalyst/moodle-mod_observation/issues/146) where the identity of the observee cannot be seen from multiple pages. This implementation also respects Moodle privacy settings.

Screenshots:

<img width="1279" height="580" alt="image" src="https://github.com/user-attachments/assets/2d806800-3eb5-45e4-9973-d082be4255ed" />

---

<img width="1235" height="522" alt="image" src="https://github.com/user-attachments/assets/c5712e1e-f80f-438d-a84b-f8589c05bfb8" />
